### PR TITLE
revolver dependency for the root sbt project

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.7")
+
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.7.2")


### PR DESCRIPTION
for some reason, sbt does not read the plugins file in the individual projects before loading them
